### PR TITLE
Redux 유틸 업데이트

### DIFF
--- a/src/@types/store.d.ts
+++ b/src/@types/store.d.ts
@@ -3,11 +3,9 @@ import { RootState } from 'store';
 declare global {
   type StoreState = RootState;
   type EntitySchema = {
-    action: {
-      request: (...p: any[]) => any;
-      success: (...p: any[]) => any;
-      failure: (...p: any[]) => any;
-    };
+    request: (...p: any[]) => any;
+    success: (...p: any[]) => any;
+    failure: (...p: any[]) => any;
     service: (...args: any[]) => any;
   };
   type EntityActions<T extends EntitySchema> = ReturnType<

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,7 @@ import React, { useEffect } from 'react';
 import { Switch, Route, useLocation } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
 import qs from 'query-string';
-import { meSaga } from 'store/auth/action';
+import { me } from 'store/auth/action';
 import { PageLayout, Nav } from 'components';
 
 import AuthCheckPage from 'pages/AuthCheckPage';
@@ -43,7 +43,7 @@ const App: React.FC = () => {
     const { accessToken } = qs.parse(search);
     console.log(accessToken);
     const token = Array.isArray(accessToken) ? accessToken[0] : accessToken;
-    dispatch(meSaga(token || undefined));
+    dispatch(me(token || undefined));
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/src/components/CommonCard.tsx
+++ b/src/components/CommonCard.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { Review } from 'models/review';
 import { formatDate } from 'utils/format';
-import { Link } from 'react-router-dom';
 import styles from 'scss/components/Card.module.scss';
 
 type Props = Pick<
@@ -21,9 +20,14 @@ const CommonCard: React.FC<Props> = ({
         <p className={styles.language}>{language}</p>
         <p className={styles.time}>{formatDate(createdAt)}</p>
       </div>
-      <Link className={styles.repo} to={repositoryUrl}>
+      <a
+        className={styles.repo}
+        href={repositoryUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
         {head}
-      </Link>
+      </a>
       <p className={styles.description}>{description}</p>
     </>
   );

--- a/src/pages/DashReviewee.tsx
+++ b/src/pages/DashReviewee.tsx
@@ -4,16 +4,18 @@ import { Nav, CardListNoti, SideBar, Loading, RevieweeCard } from 'components';
 import pageStyles from 'scss/pages/DashBoard.module.scss';
 import cardStyles from 'scss/components/Card.module.scss';
 import { UserType } from 'models/review';
-import { getUserReviewsSaga } from 'store/review/action';
+import { getUserReviews } from 'store/review/action';
 
 const DashReviewee = () => {
-  const reviews = useSelector((state: StoreState) => state.review.reviews);
+  const reviews = useSelector(
+    (state: StoreState) => state.review.userReviews.items,
+  );
   const dispatch = useDispatch();
   const isFetching = useSelector(
-    (state: StoreState) => state.review.getUserReviewsStatus !== 'SUCCESS',
+    (state: StoreState) => state.review.userReviews.status !== 'SUCCESS',
   );
   useEffect(() => {
-    dispatch(getUserReviewsSaga(UserType.REVIEWEE));
+    dispatch(getUserReviews(UserType.REVIEWEE));
   }, [dispatch]);
 
   return (

--- a/src/pages/DashReviewer.tsx
+++ b/src/pages/DashReviewer.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import cx from 'classnames';
 import { Nav, SideBar, Loading, ReviewerCard, CardListNoti } from 'components';
-import { getReviewsSaga, getUserReviewsSaga } from 'store/review/action';
+import { getReviews, getUserReviews } from 'store/review/action';
 import { UserType } from 'models/review';
 
 import cardStyles from 'scss/components/Card.module.scss';
@@ -10,19 +10,19 @@ import pageStyles from 'scss/pages/DashBoard.module.scss';
 
 const DashReviewer = () => {
   const [isReviewers, setIsReviewers] = useState(false);
-  const reviews = useSelector((state: StoreState) =>
+  const { items: reviews } = useSelector((state: StoreState) =>
     isReviewers ? state.review.reviews : state.review.userReviews,
   );
   const dispatch = useDispatch();
   const isFetching = useSelector(
-    (state: StoreState) => state.review.getReviewsStatus === 'FETCHING',
+    (state: StoreState) => state.review.reviews.status === 'FETCHING',
   );
 
   useEffect(() => {
     if (isReviewers) {
-      dispatch(getUserReviewsSaga(UserType.REVIEWER));
+      dispatch(getUserReviews(UserType.REVIEWER));
     } else {
-      dispatch(getReviewsSaga());
+      dispatch(getReviews());
     }
   }, [dispatch, isReviewers]);
 

--- a/src/pages/Start/RepoStep.tsx
+++ b/src/pages/Start/RepoStep.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState, useMemo } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import classnames from 'classnames';
-import { getReposSaga } from 'store/repo/action';
+import { getRepos } from 'store/repo/action';
 import { Link } from 'react-router-dom';
 import { RepoItem, EmptySection, Loading } from 'components';
 import { APP_NAME } from 'constants/github';
@@ -27,7 +27,7 @@ const RepoStep = () => {
     setSearchWord(e.target.value);
 
   useEffect(() => {
-    dispatch(getReposSaga());
+    dispatch(getRepos());
   }, [dispatch]);
 
   return (

--- a/src/pages/Start/ReviewStep.tsx
+++ b/src/pages/Start/ReviewStep.tsx
@@ -7,7 +7,7 @@ import GithubIcon from 'assets/img/GitHubMark.png';
 import useFetch from 'hooks/useFetch';
 import { getBranches, compareBranch } from 'api/repo';
 import { Repo } from 'models/repo';
-import { createReviewSaga } from 'store/review/action';
+import { createReview } from 'store/review/action';
 import usePrevious from 'hooks/usePrevious';
 import styles from 'scss/pages/ReviewStep.module.scss';
 
@@ -46,7 +46,7 @@ const ReviewStep: React.FC<Props> = () => {
     state.repo.repos.find(({ id }) => String(id) === repoId),
   );
   const createReviewStatus = useSelector(
-    (state: StoreState) => state.review.createReviewStatus,
+    (state: StoreState) => state.review.createReview.status,
   );
   const prevStatus = usePrevious(createReviewStatus);
 
@@ -67,7 +67,7 @@ const ReviewStep: React.FC<Props> = () => {
   const handleCreateReview = () => {
     repoId &&
       dispatch(
-        createReviewSaga(repoId, {
+        createReview(repoId, {
           title: 'temp title',
           description: message,
           base: firstBranch,

--- a/src/saga/auth.ts
+++ b/src/saga/auth.ts
@@ -1,10 +1,5 @@
 import { all, fork, take, call } from 'redux-saga/effects';
-import {
-  LoginAction,
-  loginEntity,
-  meEntity,
-  MeAction,
-} from 'store/auth/action';
+import { loginEntity, meEntity, ME, LOGIN } from 'store/auth/action';
 import { fetchEntity } from 'utils/saga';
 
 const fetchLogin = fetchEntity(loginEntity);
@@ -12,14 +7,14 @@ const fetchMe = fetchEntity(meEntity);
 
 function* watchMeSaga() {
   while (true) {
-    const { token } = yield take(MeAction.saga);
+    const { token } = yield take(ME);
     yield call(fetchMe, token);
   }
 }
 
 function* watchAuth() {
   while (true) {
-    yield take([LoginAction.saga]);
+    yield take([LOGIN]);
     yield call(fetchLogin);
   }
 }

--- a/src/saga/repo.ts
+++ b/src/saga/repo.ts
@@ -1,11 +1,11 @@
 import { all, fork, takeLatest } from 'redux-saga/effects';
-import { getReposEntity, GetReposActions } from 'store/repo/action';
+import { getReposEntity, GET_REPOS } from 'store/repo/action';
 import { fetchEntity } from 'utils/saga';
 
 const fetchGetRepos = fetchEntity(getReposEntity);
 
 function* watchGetRepos() {
-  yield takeLatest(GetReposActions.saga, fetchGetRepos);
+  yield takeLatest(GET_REPOS, fetchGetRepos);
 }
 
 export default function* root() {

--- a/src/saga/review.ts
+++ b/src/saga/review.ts
@@ -1,13 +1,13 @@
 import { all, fork, take, select, call, takeLatest } from 'redux-saga/effects';
 import {
-  GetUserReviewsActions,
   getUserReviewsEntity,
   getReviewsEntity,
-  GetReviewsActions,
-  CreateReviewActions,
-  CreateReviewSaga,
-  GetUserReviewsSaga,
   createReviewEntity,
+  CreateReview,
+  GetUserReviews,
+  CREATE_REVIEW,
+  GET_REVIEWS,
+  GET_USER_REVIEWS,
 } from 'store/review/action';
 import { fetchEntity } from 'utils/saga';
 
@@ -17,22 +17,18 @@ const createReview = fetchEntity(createReviewEntity);
 
 function* watchCreateReview() {
   while (true) {
-    const { reviewId, review }: CreateReviewSaga = yield take(
-      CreateReviewActions.saga,
-    );
+    const { reviewId, review }: CreateReview = yield take(CREATE_REVIEW);
     yield call(createReview, reviewId, review);
   }
 }
 
 function* watchReviews() {
-  yield takeLatest(GetReviewsActions.saga, fetchReviews);
+  yield takeLatest(GET_REVIEWS, fetchReviews);
 }
 
 function* watchUserReview() {
   while (true) {
-    const { userType }: GetUserReviewsSaga = yield take(
-      GetUserReviewsActions.saga,
-    );
+    const { userType }: GetUserReviews = yield take(GET_USER_REVIEWS);
     const { user } = yield select((state: StoreState) => state.auth);
     yield call(fetchUserReviews, user.id, userType);
   }

--- a/src/store/auth/action.ts
+++ b/src/store/auth/action.ts
@@ -1,31 +1,14 @@
-import { login, me } from 'api/auth';
+import * as authApi from 'api/auth';
 import { createEntity } from 'utils/redux';
 
-export enum LoginAction {
-  saga = 'LOGIN_SAGA',
-  request = 'LOGIN_REQUEST',
-  success = 'LOGIN_SUCCESS',
-  failure = 'LOGIN_FAILURE',
-}
+export const LOGIN = 'LOGIN';
+export const ME = 'ME';
 
-export enum MeAction {
-  saga = 'ME_SAGA',
-  request = 'ME_REQUEST',
-  success = 'ME_SUCCESS',
-  failure = 'ME_FAILURE',
-}
+export const loginEntity = createEntity(LOGIN, authApi.login);
+export const login = () => ({ type: LOGIN });
 
-export const loginEntity = createEntity(LoginAction, login);
-export const loginSaga = () => ({ type: LoginAction.saga });
+export const meEntity = createEntity(ME, authApi.me);
+export const me = (token?: string) => ({ type: ME, token });
 
-export const meEntity = createEntity(MeAction, me);
-export const meSaga = (token?: string) => ({ type: MeAction.saga, token });
-
-export type LoginSaga = ReturnType<typeof loginSaga>;
-export type MeSaga = ReturnType<typeof meSaga>;
-
-type AuthAction =
-  | EntityActions<typeof loginEntity>
-  | EntityActions<typeof meEntity>;
-
-export default AuthAction;
+export type Login = ReturnType<typeof login>;
+export type Me = ReturnType<typeof me>;

--- a/src/store/auth/index.ts
+++ b/src/store/auth/index.ts
@@ -1,7 +1,6 @@
-import produce from 'immer';
-import { createReducer, baseAsyncActionHandler } from 'utils/redux';
+import { createReducer } from 'utils/redux';
 import { User } from 'models/user';
-import AuthAction, { LoginAction, MeAction } from './action';
+import { meEntity } from './action';
 
 export type AuthState = {
   user: User & {
@@ -24,19 +23,25 @@ const initialState: AuthState = {
   meStatus: 'INIT',
 };
 
-const reducer = createReducer<AuthAction, AuthState>(initialState, {
-  ...baseAsyncActionHandler('loginStatus', LoginAction),
-  ...baseAsyncActionHandler('meStatus', MeAction),
-  [MeAction.success]: (state, action) => {
-    return produce(state, draft => {
-      draft.meStatus = 'SUCCESS';
-      draft.user.isLoggedIn = true;
-      draft.user = {
+const reducer = createReducer(initialState, switcher => {
+  switcher
+    .addCase(meEntity.request, state => {
+      state.meStatus = 'FETCHING';
+    })
+    .addCase(meEntity.success, (state, action) => {
+      state.meStatus = 'SUCCESS';
+      state.user = {
         ...action.payload,
         isLoggedIn: true,
       };
+    })
+    .addCase(meEntity.failure, state => {
+      state.meStatus = 'FAILURE';
+      state.user = {
+        ...initialState.user,
+        isLoggedIn: false,
+      };
     });
-  },
 });
 
 export default reducer;

--- a/src/store/repo/action.ts
+++ b/src/store/repo/action.ts
@@ -1,18 +1,7 @@
-import { getRepos } from 'api/repo';
+import * as repoApi from 'api/repo';
 import { createEntity } from 'utils/redux';
 
-export enum GetReposActions {
-  saga = 'GET_REPOS_SAGA',
-  request = 'GET_REPOS_REQUEST',
-  success = 'GET_REPOS_SUCCESS',
-  failure = 'GET_REPOS_FAILURE',
-}
+export const GET_REPOS = 'GET_REPOS' as const;
 
-export const getReposEntity = createEntity(GetReposActions, getRepos);
-export const getReposSaga = () => ({ type: GetReposActions.saga });
-
-export type GetReposSaga = ReturnType<typeof getReposSaga>;
-
-type RepoAction = EntityActions<typeof getReposEntity>;
-
-export default RepoAction;
+export const getReposEntity = createEntity(GET_REPOS, repoApi.getRepos);
+export const getRepos = () => ({ type: GET_REPOS });

--- a/src/store/repo/index.ts
+++ b/src/store/repo/index.ts
@@ -1,7 +1,6 @@
-import produce from 'immer';
-import { createReducer, baseAsyncActionHandler } from 'utils/redux';
+import { createReducer } from 'utils/redux';
+import { getReposEntity } from 'store/repo/action';
 import { Repo } from 'models/repo';
-import RepoAction, { GetReposActions } from './action';
 
 export type RepoState = {
   repos: Repo[];
@@ -13,12 +12,16 @@ const initialState: RepoState = {
   getReposStatus: 'INIT',
 };
 
-export default createReducer<RepoAction, RepoState>(initialState, {
-  ...baseAsyncActionHandler('getReposStatus', GetReposActions),
-  [GetReposActions.success]: (state, action) => {
-    return produce(state, draft => {
-      draft.repos = action.payload;
-      draft.getReposStatus = 'SUCCESS';
+export default createReducer(initialState, switcher => {
+  switcher
+    .addCase(getReposEntity.request, state => {
+      state.getReposStatus = 'FETCHING';
+    })
+    .addCase(getReposEntity.success, (state, action) => {
+      state.getReposStatus = 'SUCCESS';
+      state.repos = action.payload;
+    })
+    .addCase(getReposEntity.failure, state => {
+      state.getReposStatus = 'FAILURE';
     });
-  },
 });

--- a/src/store/review/action.ts
+++ b/src/store/review/action.ts
@@ -1,58 +1,35 @@
-import { createReview, getUserReviews, getReviews } from 'api/review';
+import * as reviewApi from 'api/review';
 import { createEntity } from 'utils/redux';
 import { UserType, NewReview } from 'models/review';
 
-export enum GetReviewsActions {
-  saga = 'GET_REVIEWS_SAGA',
-  request = 'GET_REVIEWS_REQUEST',
-  success = 'GET_REVIEWS_SUCCESS',
-  failure = 'GET_REVIEWS_FAILURE',
-}
-export enum GetUserReviewsActions {
-  saga = 'GET_USER_REVIEWS_SAGA',
-  request = 'GET_USER_REVIEWS_REQUEST',
-  success = 'GET_USER_REVIEWS_SUCCESS',
-  failure = 'GET_USER_REVIEWS_FAILURE',
-}
+export const GET_REVIEWS = 'GET_REVIEWS';
+export const GET_USER_REVIEWS = 'GET_USER_REVIEWS';
+export const CREATE_REVIEW = 'CREATE_REVIEW';
 
-export enum CreateReviewActions {
-  saga = 'CREATE_REVIEW_SAGA',
-  request = 'CREATE_REVIEW_REQUEST',
-  success = 'CREATE_REVIEW_SUCCESS',
-  failure = 'CREATE_REVIEW_FAILURE',
-}
-
-export const getReviewsEntity = createEntity(GetReviewsActions, getReviews);
-export const getReviewsSaga = () => ({
-  type: GetReviewsActions.saga,
+export const getReviewsEntity = createEntity(GET_REVIEWS, reviewApi.getReviews);
+export const getReviews = () => ({
+  type: GET_REVIEWS,
 });
 
 export const getUserReviewsEntity = createEntity(
-  GetUserReviewsActions,
-  getUserReviews,
+  GET_USER_REVIEWS,
+  reviewApi.getUserReviews,
 );
-export const getUserReviewsSaga = (userType: UserType) => ({
-  type: GetUserReviewsActions.saga,
+export const getUserReviews = (userType: UserType) => ({
+  type: GET_USER_REVIEWS,
   userType,
 });
 
 export const createReviewEntity = createEntity(
-  CreateReviewActions,
-  createReview,
+  CREATE_REVIEW,
+  reviewApi.createReview,
 );
-export const createReviewSaga = (reviewId: string, review: NewReview) => ({
-  type: CreateReviewActions.saga,
+export const createReview = (reviewId: string, review: NewReview) => ({
+  type: CREATE_REVIEW,
   reviewId,
   review,
 });
 
-export type GetReviewsSaga = ReturnType<typeof getReviewsSaga>;
-export type GetUserReviewsSaga = ReturnType<typeof getUserReviewsSaga>;
-export type CreateReviewSaga = ReturnType<typeof createReviewSaga>;
-
-type ReviewAction =
-  | EntityActions<typeof createReviewEntity>
-  | EntityActions<typeof getReviewsEntity>
-  | EntityActions<typeof getUserReviewsEntity>;
-
-export default ReviewAction;
+export type GetReviews = ReturnType<typeof getReviews>;
+export type GetUserReviews = ReturnType<typeof getUserReviews>;
+export type CreateReview = ReturnType<typeof createReview>;

--- a/src/utils/redux.ts
+++ b/src/utils/redux.ts
@@ -1,5 +1,77 @@
 import { Action } from 'redux';
-import produce from 'immer';
+import produce, { Draft } from 'immer';
+
+// Action Map 타입
+type Actions<T extends keyof any = string> = Record<T, Action>;
+// type property 를 가지는 액션 creator
+type TypedActionCreator<Type extends string> = {
+  (...args: any[]): Action<Type>;
+  type: Type;
+};
+// type이 있는 ActionCreator 만들기
+export const createAction = <P, Type extends string = string>(type: Type) => {
+  const fn = (payload: P) => ({
+    type,
+    payload,
+  });
+  fn.type = type;
+  return fn;
+};
+// entity 만들기 - 비동기일 때 사용
+export const createEntity = <Params extends any[], Res>(
+  prefix: string,
+  service: Service<Params, Res>,
+) => ({
+  request: createAction<Params>(`${prefix}_REQUEST`),
+  success: createAction<Res>(`${prefix}_SUCCESS`),
+  failure: createAction<string>(`${prefix}_FAILURE`),
+  service,
+});
+// 내부적으로 immer를 사용하는 handler
+type Handler<S, AC extends TypedActionCreator<string>> = (
+  state: Draft<S>,
+  action: ReturnType<AC>,
+) => S | void;
+// handler map
+type Handlers<S, AS extends Actions> = {
+  [T in keyof AS]: AS[T] extends Action
+    ? Handler<S, TypedActionCreator<AS[T]['type']>>
+    : void;
+};
+// addCase를 통해 reducer의 switch 케이스를 만드는 클래스
+class Switcher<S> {
+  switcherMap: Handlers<S, any> = {};
+  addCase<Type extends string, AC extends TypedActionCreator<Type>>(
+    action: AC,
+    handler: Handler<S, AC>,
+  ) {
+    this.switcherMap[action.type] = handler;
+    return this;
+  }
+}
+// 리듀서 만들기
+export const createReducer = <S>(
+  initialState: S,
+  createSwitcher: (builder: Switcher<S>) => void,
+) => {
+  const switcher = new Switcher<S>();
+  createSwitcher(switcher);
+  const { switcherMap } = switcher;
+  const reducer = (state: S = initialState, action: any) => {
+    if (action.type in switcherMap) {
+      const matchHandle = switcherMap[action.type];
+      return matchHandle
+        ? produce(state, draft => matchHandle(draft, action))
+        : state;
+    }
+    return state;
+  };
+
+  return reducer;
+};
+
+/*
+간편한 리듀서 만들기 초안..
 
 type GetAction<
   TAction extends Action,
@@ -82,3 +154,4 @@ export const baseAsyncActionHandler = <
     },
   };
 };
+*/

--- a/src/utils/saga.ts
+++ b/src/utils/saga.ts
@@ -1,14 +1,19 @@
 import { call, put } from 'redux-saga/effects';
 
-export const fetchEntity = ({ action, service }: EntitySchema) => {
+export const fetchEntity = ({
+  request,
+  success,
+  failure,
+  service,
+}: EntitySchema) => {
   return function*(...args: any[]) {
-    yield put(action.request());
+    yield put(request());
     try {
       const response = yield call(service, ...args);
-      yield put(action.success(response));
+      yield put(success(response));
     } catch (err) {
       // TODO: error reducer 따로 만들기.
-      yield put(action.failure());
+      yield put(failure());
     }
   };
 };


### PR DESCRIPTION
- 리덕스 유틸 만든거 업데이트
  - 쓸데없이 필요한것들이 좀 있었던 것 같음. saga를 postfix로 넣어야된다던가, 액션을 다 만들어줘야 된다던가..
  - action은 리듀서에서만 쓰면 되는데 enum으로 다 만들어줄 필요 없을 것 같아서 처음 호출하는 액션 (saga에서 받는 액션)만 만들어 주고 나머지는 유틸리티로 생성하도록 수정
  - 이렇게 하려면 유니온 액션타입에 대한 분기가 필요한데, `createReducer`를 좀 손봤음
